### PR TITLE
Fix disable bitcode statement in targets

### DIFF
--- a/OpenSSL-Apple.podspec
+++ b/OpenSSL-Apple.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
     s.license         = { :type => 'Apache', :file => 'LICENSE' }
 
     s.prepare_command = <<-CMD
-./build-libssl.sh --version="#{openssl_version}" --targets="#{openssl_targets} --disable-bitcode"
+./build-libssl.sh --version="#{openssl_version}" --targets="#{openssl_targets}" --disable-bitcode
 ./create-openssl-framework.sh dynamic
     CMD
 


### PR DESCRIPTION
Cocoapods tries to build targets with bitcode. Current version of podspec looks like a typo