### PR TITLE
Add arm64 target for Apple TV Simulator

### DIFF
--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -33,7 +33,7 @@ ios-sim-cross-x86_64 ios-sim-cross-arm64 ios64-cross-arm64 ios64-cross-arm64e
 macos64-x86_64 macos64-arm64
 mac-catalyst-x86_64 mac-catalyst-arm64
 watchos-cross-armv7k watchos-cross-arm64_32 watchos-sim-cross-x86_64 watchos-sim-cross-i386 watchos-sim-cross-arm64
-tvos-sim-cross-x86_64 tvos64-cross-arm64
+tvos-sim-cross-x86_64 tvos-sim-cross-arm64 tvos-cross-arm64
 TARGETS`
 
 # Minimum iOS/tvOS SDK version to build for
@@ -612,6 +612,9 @@ if [ ${#OPENSSLCONF_ALL[@]} -gt 1 ]; then
       ;;
       *_tvos_arm64.h)
         DEFINE_CONDITION="TARGET_OS_TV && TARGET_OS_EMBEDDED && TARGET_CPU_ARM64"
+      ;;
+      *_tvos_sim_arm64.h)
+        DEFINE_CONDITION="TARGET_OS_TV && TARGET_OS_SIMULATOR && TARGET_CPU_ARM64"
       ;;
       *_tvos_sim_x86_64.h)
         DEFINE_CONDITION="TARGET_OS_TV && TARGET_OS_SIMULATOR && TARGET_CPU_X86_64"

--- a/config/20-all-platforms.conf
+++ b/config/20-all-platforms.conf
@@ -134,7 +134,7 @@ my %targets = ();
     ## Apple TV
 
     # Device
-    "tvos64-cross-arm64" => {
+    "tvos-cross-arm64" => {
         inherit_from     => [ "darwin-common", "tvos-cross-base" ],
         cflags           => add("-arch arm64"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
@@ -142,6 +142,11 @@ my %targets = ();
         sys_id           => "tvOS",
     },
     # Simulator
+    "tvos-sim-cross-arm64" => {
+        inherit_from     => [ "darwin64-arm64", "tvos-cross-base" ],
+        cflags           => add("-target arm64-apple-tvos12.0-simulator"),
+        sys_id           => "tvOS",
+    },
     "tvos-sim-cross-x86_64" => {
         inherit_from     => [ "darwin64-x86_64-cc", "tvos-cross-base" ],
         sys_id           => "tvOS",

--- a/scripts/build-loop-targets.sh
+++ b/scripts/build-loop-targets.sh
@@ -57,7 +57,7 @@ do
     PLATFORM="WatchOS"
   elif [[ "${TARGET}" == "tvos-sim-cross-"* ]]; then
     PLATFORM="AppleTVSimulator"
-  elif [[ "${TARGET}" == "tvos64-cross-"* ]]; then
+  elif [[ "${TARGET}" == "tvos-cross-"* ]]; then
     PLATFORM="AppleTVOS"
   elif [[ "${TARGET}" == "ios-sim-cross-"* ]]; then
     PLATFORM="iPhoneSimulator"


### PR DESCRIPTION
A target for Apple TV Simulator on Apple Silicon platforms (M1 and later) was missing.