### PR TITLE
Mix OpenSSL patch and script version

### DIFF
--- a/scripts/get-openssl-version.sh
+++ b/scripts/get-openssl-version.sh
@@ -12,5 +12,8 @@ function get_openssl_version() {
     echo $normalized_version
     return
   fi
-  echo "${std_version}${script_version}"
+  local minor_version="${std_version%.*}"
+  local patch_version="${std_version##*.}"
+  local normalized_patch_version=$((($patch_version + 1) * 100 + $script_version))
+  echo "${minor_version}.${normalized_patch_version}"
 }


### PR DESCRIPTION
SwiftPM only allows major.minor.patch version syntax, but we need to avoid collisions.

E.g. OpenSSL 3.2.5 and script version 34 (0-99)

normalized_patch = (patch + 1) * 100 + script

-> 3.2.634

The +1 is necessary because e.g. 3.2.0 with script 34 would translate to 3.2.34, which collides with OpenSSL versioning.

In this scheme, the repo tag will be of the form:

- .1xx (for 3.2.0)
- .2xx (for 3.2.1)
- ...

which is reversible to infer the OpenSSL patch.

E.g. 3.2.434

- Patch is 434
- OpenSSL patch is 434 / 100 - 1 = 3
- Script version is 434 % 100 = 34 (precondition is 0-99)

So 3.2.434 is OpenSSL 3.2.3 with script version 34