### PR TITLE
🐛 Configure curl to follow redirects

### DIFF
--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -488,14 +488,14 @@ if [ ! -e ${OPENSSL_ARCHIVE_FILE_NAME} ]; then
 
   # Check whether file exists here (this is the location of the latest version for each branch)
   # -s be silent, -f return non-zero exit status on failure, -I get header (do not download)
-  curl ${CURL_OPTIONS} -sfI "${OPENSSL_ARCHIVE_URL}" > /dev/null
+  curl ${CURL_OPTIONS} -sfIL "${OPENSSL_ARCHIVE_URL}" > /dev/null
 
   # If unsuccessful, update the URL for older versions and try again.
   if [ $? -ne 0 ]; then
     BRANCH=$(echo "${VERSION}" | grep -Eo '^[0-9]\.[0-9]\.[0-9]')
     OPENSSL_ARCHIVE_URL="https://www.openssl.org/source/old/${BRANCH}/${OPENSSL_ARCHIVE_FILE_NAME}"
 
-    curl ${CURL_OPTIONS} -sfI "${OPENSSL_ARCHIVE_URL}" > /dev/null
+    curl ${CURL_OPTIONS} -sfIL "${OPENSSL_ARCHIVE_URL}" > /dev/null
   fi
 
   # Both attempts failed, so report the error
@@ -507,9 +507,9 @@ if [ ! -e ${OPENSSL_ARCHIVE_FILE_NAME} ]; then
 
   # Archive was found, so proceed with download.
   # -O Use server-specified filename for download
-  curl ${CURL_OPTIONS} -O "${OPENSSL_ARCHIVE_URL}"
+  curl ${CURL_OPTIONS} -OL "${OPENSSL_ARCHIVE_URL}"
   # also download the gpg signature from the same location
-  curl ${CURL_OPTIONS} -O "${OPENSSL_ARCHIVE_URL}${OPENSSL_ARCHIVE_SIGNATURE_FILE_EXT}"
+  curl ${CURL_OPTIONS} -OL "${OPENSSL_ARCHIVE_URL}${OPENSSL_ARCHIVE_SIGNATURE_FILE_EXT}"
 
 else
   echo "Using ${OPENSSL_ARCHIVE_FILE_NAME}"


### PR DESCRIPTION
Fixes #67

The OpenSSL site has recently changed causing the download URLs used by the `build-libssl.sh` script to start failing.

Upstream issue: openssl/web#490

This PR add the `-L` (aka `--location`) option, which tells curl to use the Location header of 30x responses to request the resource at the new location. This allows the download request to follow the new redirects to the correct download URL.

## Before

```
❯ curl -sfI https://www.openssl.org/source/old/3.2.0/openssl-3.2.0.tar.gz
HTTP/2 301
cache-control: private
location: https://github.com:443/openssl/openssl/releases/download/openssl-3.2.0/openssl-3.2.0.tar.gz
content-length: 0
date: Mon, 29 Jul 2024 18:10:19 GMT
content-type: text/html; charset=UTF-8
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
```

## After

```
❯ curl -sfIL https://www.openssl.org/source/old/3.2.0/openssl-3.2.0.tar.gz
HTTP/2 301
cache-control: private
location: https://github.com:443/openssl/openssl/releases/download/openssl-3.2.0/openssl-3.2.0.tar.gz
content-length: 0
date: Mon, 29 Jul 2024 18:21:32 GMT
content-type: text/html; charset=UTF-8
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000

HTTP/2 302
server: GitHub.com
date: Mon, 29 Jul 2024 18:21:32 GMT
content-type: text/html; charset=utf-8
vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/7634677/b148b963-46ad-4ab1-aab0-a14d5b5c722f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240729%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240729T182132Z&X-Amz-Expires=300&X-Amz-Signature=47a8ff5a038a306a2fdc9544c2e8247852c755a002b5b94655677c7433c5ede1&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=7634677&response-content-disposition=attachment%3B%20filename%3Dopenssl-3.2.0.tar.gz&response-content-type=application%2Foctet-stream
cache-control: no-cache
strict-transport-security: max-age=31536000; includeSubdomains; preload
x-frame-options: deny
x-content-type-options: nosniff
x-xss-protection: 0
referrer-policy: no-referrer-when-downgrade
content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com api.githubcopilot.com objects-origin.githubusercontent.com copilot-proxy.githubusercontent.com/v1/engines/github-completion/completions proxy.enterprise.githubcopilot.com/v1/engines/github-completion/completions *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: blob: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
content-length: 0
x-github-request-id: C8C1:31C64:E5B0D3:1486CBE:66A7DDAC

HTTP/2 200
content-type: application/octet-stream
content-md5: eQNUmhSr68XDI85OhfLLsg==
last-modified: Thu, 23 Nov 2023 13:37:13 GMT
etag: "0x8DBEC294D36A53A"
server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
x-ms-request-id: dbea5281-801e-0034-09f2-dcd29d000000
x-ms-version: 2020-10-02
x-ms-creation-time: Thu, 23 Nov 2023 13:37:13 GMT
x-ms-lease-status: unlocked
x-ms-lease-state: available
x-ms-blob-type: BlockBlob
content-disposition: attachment; filename=openssl-3.2.0.tar.gz
x-ms-server-encrypted: true
via: 1.1 varnish, 1.1 varnish
fastly-restarts: 1
accept-ranges: bytes
age: 639
date: Mon, 29 Jul 2024 18:21:32 GMT
x-served-by: cache-iad-kiad7000117-IAD, cache-den8221-DEN
x-cache: HIT, HIT
x-cache-hits: 0, 0
x-timer: S1722277292.463280,VS0,VE1
content-length: 17698352
```