### PR TITLE
Add GitHub download URL fallback

### DIFF
--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -490,6 +490,13 @@ if [ ! -e ${OPENSSL_ARCHIVE_FILE_NAME} ]; then
   # -s be silent, -f return non-zero exit status on failure, -I get header (do not download)
   curl ${CURL_OPTIONS} -sfIL "${OPENSSL_ARCHIVE_URL}" > /dev/null
 
+  # If unsuccessful, use the GitHub URL for newer versions and try again.
+  if [ $? -ne 0 ]; then
+    OPENSSL_ARCHIVE_URL="https://github.com/openssl/openssl/releases/download/${OPENSSL_ARCHIVE_BASE_NAME}/${OPENSSL_ARCHIVE_FILE_NAME}"
+
+    curl ${CURL_OPTIONS} -sfIL "${OPENSSL_ARCHIVE_URL}" > /dev/null
+  fi
+
   # If unsuccessful, update the URL for older versions and try again.
   if [ $? -ne 0 ]; then
     BRANCH=$(echo "${VERSION}" | grep -Eo '^[0-9]\.[0-9]\.[0-9]')


### PR DESCRIPTION
fixes passepartoutvpn/openssl-apple#69

This is a relatively non-invasive fix.
I added a second fallback mechanism before the fallback for older versions.
Also, this does not have the regex-issue mentioned in #69, since it does not depend on the regex.

It is possible that this fallback URL to GitHub should become the new default URL, since old versions are still available via the fallback and newer versions can be found on GitHub.

The safest bet should be just leaving this as fallback for now though.
